### PR TITLE
Fix script & deploy to both infrastructures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,16 @@ deploy: build
 	docker push ${REGISTRY_URL}/pttp-${ENV}-ima-blackbox-exporter:latest
 	./scripts/restart_ecs_service.sh
 
+build_mojo:
+	docker build --build-arg SHARED_SERVICES_ACCOUNT_ID=${SHARED_SERVICES_ACCOUNT_ID} -t mojo-${ENV}-ima-blackbox-exporter .
+
+deploy_mojo: build
+	echo ${REGISTRY_URL}
+	aws ecr get-login-password | docker login --username AWS --password-stdin ${REGISTRY_URL}
+	docker tag mojo-${ENV}-ima-blackbox-exporter:latest ${REGISTRY_URL}/mojo-${ENV}-ima-blackbox-exporter:latest
+	docker push ${REGISTRY_URL}/mojo-${ENV}-ima-blackbox-exporter:latest
+	./scripts/restart_ecs_service_mojo.sh
+
 serve:
 	docker run -d -p 9115:9115 --name blackbox-exporter pttp-${ENV}-ima-blackbox-exporter
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,3 +15,4 @@ phases:
     commands:
       - make authenticate_docker
       - make deploy
+      - make deploy_mojo

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,4 +15,5 @@ phases:
     commands:
       - make authenticate_docker
       - make deploy
-      - make deploy_mojo
+      # To uncomment in tandem with the CIDR range change
+      # - make deploy_mojo

--- a/scripts/restart_ecs_service _mojo.sh
+++ b/scripts/restart_ecs_service _mojo.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This deployment script starts a zero downtime phased deployment.
+# It works by doubling the currently running tasks by introducing the new versions
+# Auto scaling will detect that there are too many tasks running for the current load and slowly start decomissioning the old running tasks
+# Production traffic will gradually be moved to the new running tasks
+
+set -e
+
+assume_deploy_role() {
+  TEMP_ROLE=`aws sts assume-role --role-arn $ROLE_ARN --role-session-name ci-ima-deploy-$CODEBUILD_BUILD_NUMBER`
+  export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
+  export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+  export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
+}
+
+deploy() {
+  cluster_name=mojo-${ENV}-ima-ecs-cluster
+  service_name=mojo-${ENV}-ima-blackbox_exporter-ecs-service
+
+  aws ecs update-service \
+    --cluster $cluster_name \
+    --service $service_name \
+    --force-new-deployment
+}
+
+main() {
+  if [ "$CODEBUILD_CI" = "true" ]
+  then
+    assume_deploy_role
+  fi
+
+  deploy
+}
+
+main

--- a/scripts/restart_ecs_service.sh
+++ b/scripts/restart_ecs_service.sh
@@ -25,7 +25,11 @@ deploy() {
 }
 
 main() {
-  assume_deploy_role
+  if [ "$CODEBUILD_CI" = "true" ]
+  then
+    assume_deploy_role
+  fi
+
   deploy
 }
 


### PR DESCRIPTION
1, The restart ecs script wasn't working on local dev due to the assume_role function. This PR wraps the calling of this function in an IF statement.

2, We are temporarily running two lots of infrastructure, on different IP ranges. This changes the buildspec to deploy to both of these infrastructures.