### PR TITLE
Pushing blackbox to mojo VPC through the pipeline

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,5 +14,6 @@ phases:
     commands:
       - make publish
       - make deploy
-      # To uncomment in tandem with the CIDR range change
-      # - make deploy_mojo
+      - make publish_mojo
+      - make deploy_mojo
+


### PR DESCRIPTION
Adding make publish_mojo and make deploy_mojo to the buildspec.yml will now deploy a second Blackbox Exporter(same config) to the new mojo VPC.