### PR TITLE
🔧 increasing probe timeout to 15s

### DIFF
--- a/blackbox.yml
+++ b/blackbox.yml
@@ -1,7 +1,7 @@
 modules:
   http_2xx:
     prober: http
-    timeout: 10s
+    timeout: 15s
     http:
       method: GET
       valid_status_codes: []


### PR DESCRIPTION
Processing is timing out after 10 seconds intranet.noms.gsi.gov.uk which is causing issue on alerting. Increasing timeout to 15s.