### PR TITLE
💫  add-new-github-actions

### DIFF
--- a/.github/workflows/issue-to-jira-trigger.yml
+++ b/.github/workflows/issue-to-jira-trigger.yml
@@ -1,0 +1,14 @@
+name: Add Issue to Jira Board On Close
+
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  call-workflow-issue-to-jira:
+    uses: ministryofjustice/cloud-operations-github-actions/.github/workflows/issue-to-jira.yml@main
+    secrets:
+      TECH_SERVICES_JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
+      TECH_SERVICES_JIRA_EMAIL: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
+      TECH_SERVICES_JIRA_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}

--- a/.github/workflows/issue-to-project-trigger.yml
+++ b/.github/workflows/issue-to-project-trigger.yml
@@ -1,0 +1,12 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  call-workflow-issue-to-project:
+    uses: ministryofjustice/cloud-operations-github-actions/.github/workflows/issue-to-project.yml@main
+    secrets:
+      TECH_SERVICES_GITHUB_TOKEN: ${{ secrets.TECH_SERVICES_GITHUB_TOKEN }}


### PR DESCRIPTION
Adds two new Github actions:

- Automatically adds GitHub issues to the Cloud Operations project board when an issue is created.
- Automatically creates and closes a Jira issue on the CNSA Jira board when an issue is closed.